### PR TITLE
stdin works on Windows, too, without regressing issue #5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
           key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
       - name: install deps
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: rm -rf poetry.lock && make install
+        run: rm poetry.lock && make install
       - name: test
         run: make test
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -49,14 +49,12 @@ jobs:
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
-      - name: install windows deps
-        if: matrix.os == 'windows-latest'
-        run: choco install make
       - name: install deps
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: rm poetry.lock && make install
+        run: rm -rf poetry.lock && make install
       - name: test
         run: make test
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+        

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,9 @@ jobs:
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
+      - name: install windows deps
+        if: matrix.os == 'windows-latest'
+        run: choco install make
       - name: install deps
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: rm poetry.lock && make install

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -83,7 +83,6 @@ def test_no_stdin_error(monkeypatch: MonkeyPatch) -> None:
     Couldn't find a better way to test the CLI without patching everything :(
     """
     runner = CliRunner()
-    class_mock = Mock()
     isatty_mock = Mock()
     with monkeypatch.context():
         isatty_mock.return_value = True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,10 +3,11 @@ from io import BytesIO
 from pathlib import Path
 from unittest.mock import Mock
 
+import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from typer.testing import CliRunner
 
-from rexi.cli import app
+from rexi.cli import app, is_stdin_a_tty
 
 
 def test_no_args(monkeypatch: MonkeyPatch) -> None:
@@ -89,3 +90,12 @@ def test_no_stdin_error(monkeypatch: MonkeyPatch) -> None:
         monkeypatch.setattr("rexi.cli.is_stdin_a_tty", isatty_mock)
         result = runner.invoke(app)
     assert "Invalid value" in result.output
+
+
+@pytest.mark.parametrize('input_value', [True, False])
+def test_is_stdin_a_tty(monkeypatch: MonkeyPatch, input_value: bool) -> None:
+    isatty_mock = Mock()
+    with monkeypatch.context():
+        isatty_mock.return_value = input_value
+        monkeypatch.setattr("rexi.cli.sys.stdin.isatty", isatty_mock)
+        assert is_stdin_a_tty() == input_value


### PR DESCRIPTION
This fixes #12 

This makes rexi work on Windows again, and is also a good fix for issue #5 where rexi was waiting for input forever when no input was given.

I have run the unit tests and other checks on both Windows and Linux, and everything seems to be working as expected.

I'm not going to guarantee that it will work on any version of Windows older than Windows 10, but given that Windows 10 is EOL in about a year and a half that shouldn't matter.